### PR TITLE
Bugfix/token wihout email

### DIFF
--- a/src/JwtAuthentication/TokenHydrator.php
+++ b/src/JwtAuthentication/TokenHydrator.php
@@ -39,7 +39,7 @@ class TokenHydrator extends AbstractHydrator
 
         $object
             ->setClientId($clientId)
-            ->setEmail($data['email']??null)
+            ->setEmail($data['email'] ?? null)
             ->setExp($data['exp'])
             ->setIss($data['iss'])
             ->setSub($data['sub'])

--- a/src/JwtAuthentication/TokenHydrator.php
+++ b/src/JwtAuthentication/TokenHydrator.php
@@ -39,7 +39,7 @@ class TokenHydrator extends AbstractHydrator
 
         $object
             ->setClientId($clientId)
-            ->setEmail($data['email'])
+            ->setEmail($data['email']??null)
             ->setExp($data['exp'])
             ->setIss($data['iss'])
             ->setSub($data['sub'])


### PR DESCRIPTION
A warning message is displayed in the logs when there is not email in the authentication token.
This happens, for example, when we make the authentication with the admin account or when the authentication is with tokens in a machine to machine interaction.